### PR TITLE
feat: send customer near-arrival SSE when rider approaches destination

### DIFF
--- a/docs/near-arrival-notification.md
+++ b/docs/near-arrival-notification.md
@@ -1,0 +1,103 @@
+# 라이더 근접 도착 알림(“곧 도착”) 구현 가이드
+
+현재 코드베이스는 이미 다음 기반 요소를 가지고 있습니다.
+
+- 라이더 위치 업데이트 API: `POST /riders/{riderId}/location`
+- 라이더 위치 조회 API: `GET /riders/{riderId}/location`
+- SSE 기반 실시간 알림 패턴(라이더 배차 알림): `RiderDispatchNotificationService`
+- 좌표 간 거리 계산 유틸: `Location.calculateDistanceInHaversineFormula`
+
+이를 활용해 주문자에게 “배달이 얼마 안 남았음”을 알리려면 아래와 같이 설계하면 됩니다.
+
+## 1) 알림 조건 정의
+
+알림은 고정 거리 또는 ETA 기반으로 트리거합니다.
+
+- **거리 기반(권장 시작점)**: 라이더-도착지 거리 <= 500m 일 때 알림
+- **ETA 기반(확장)**: 지도 API 기반 남은 시간 <= 3분 일 때 알림
+
+초기에는 운영 복잡도가 낮은 거리 기반부터 시작하고, 이후 ETA로 고도화하는 것이 안전합니다.
+
+## 2) 이벤트 발생 지점
+
+가장 자연스러운 트리거는 라이더 앱이 주기적으로 호출하는 위치 업데이트 시점입니다.
+
+1. 라이더 앱이 3~5초마다 위치 전송
+2. 서버가 `updateRiderLocation`에서 좌표 저장
+3. 같은 트랜잭션(또는 직후)에서 배달 건 조회
+4. 도착지 거리 계산 후 임계값 이하면 주문자 알림 발송
+
+즉, 별도 스케줄러 없이도 “푸시형”으로 near-arrival 이벤트를 생성할 수 있습니다.
+
+## 3) 중복 알림 방지(필수)
+
+위치 업데이트가 자주 들어오기 때문에 중복 발송 방지 플래그가 필요합니다.
+
+예시 필드:
+
+- `Delivery.nearArrivalNotified` (boolean, default false)
+
+발송 로직:
+
+- 조건 충족 && `nearArrivalNotified == false` 일 때만 발송
+- 발송 성공 후 `nearArrivalNotified = true`
+
+## 4) 주문자 알림 채널
+
+현재 프로젝트에 SSE 패턴이 이미 있으므로 동일하게 적용 가능합니다.
+
+- 구독 API 예시: `GET /orders/{orderId}/notifications/subscribe`
+- 이벤트명 예시: `delivery-near-arrival`
+- payload 예시:
+  - `orderId`
+  - `deliveryId`
+  - `riderId`
+  - `remainingDistanceKm`
+  - `message` (예: “라이더가 곧 도착합니다.”)
+
+추후 모바일 푸시(Firebase/APNs)로 확장할 때도 같은 도메인 이벤트를 재사용할 수 있습니다.
+
+## 5) 서버 처리 의사 코드
+
+```java
+public RiderLocationResponse updateRiderLocation(Long riderId, double latitude, double longitude) {
+    Rider rider = riderRepository.findById(riderId)...;
+    rider.updateLocation(latitude, longitude);
+
+    List<Delivery> activeDeliveries = deliveryRepository
+        .findByRiderIdAndStatusIn(riderId, List.of(DISPATCHED, PICKED_UP));
+
+    for (Delivery delivery : activeDeliveries) {
+        Location destination = delivery.getOrder().getDeliveryLocation();
+        double distanceKm = rider.getLocation().calculateDistanceInHaversineFormula(destination);
+
+        if (distanceKm <= 0.5 && !delivery.isNearArrivalNotified()) {
+            customerNotificationService.notifyNearArrival(delivery, distanceKm);
+            delivery.markNearArrivalNotified();
+        }
+    }
+
+    return RiderLocationResponse.of(rider);
+}
+```
+
+## 6) 운영 관점 체크리스트
+
+- 위치 수집 주기: 3~5초(도심), 5~10초(배터리 절약)
+- 오래된 위치 무시: `updatedAt` 기준 stale 데이터 필터링
+- 상태 제한: `DELIVERED`, `CANCEL` 건은 제외
+- 오차 완화: GPS 튐 방지를 위해 2회 연속 임계값 만족 시 발송(선택)
+- 장애 대응: SSE 실패 시 emitter 정리 + 재연결 전략
+
+## 7) 단계적 적용 순서
+
+1. 거리 임계값 상수화 (`NEAR_ARRIVAL_THRESHOLD_KM = 0.5`)
+2. Delivery 엔티티에 중복 발송 방지 필드 추가
+3. 활성 배달 조회 repository 메서드 추가
+4. 주문자용 SSE NotificationService/Controller 추가
+5. `updateRiderLocation`에 near-arrival 검사/발송 연동
+6. 통합 테스트(구독 후 위치 업데이트 -> 이벤트 수신) 추가
+
+## 8) 한 줄 요약
+
+**라이더 위치 업데이트 API를 이벤트 소스로 사용하고, 라이더-도착지 거리 임계값 + 중복 방지 플래그를 결합해 SSE로 주문자에게 “곧 도착” 알림을 보내는 구조가 가장 단순하고 안정적입니다.**

--- a/src/main/java/personal/yejin/foodDelivery/domain/delivery/model/Delivery.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/delivery/model/Delivery.java
@@ -38,6 +38,9 @@ public class Delivery extends GlobalEntity {
     @JoinColumn(name = "route_id")
     private Route route;
 
+    @Column(name = "near_arrival_notified", nullable = false)
+    private boolean nearArrivalNotified;
+
     public void setRider(Rider rider) {
         this.rider = rider;
     }
@@ -52,9 +55,14 @@ public class Delivery extends GlobalEntity {
         this.order = order;
         this.deliveryType = deliveryType;
         this.status = DeliveryStatus.PENDING;
+        this.nearArrivalNotified = false;
     }
 
     public void updateStatus(DeliveryStatus status) {
         this.status = status;
+    }
+
+    public void markNearArrivalNotified() {
+        this.nearArrivalNotified = true;
     }
 }

--- a/src/main/java/personal/yejin/foodDelivery/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/delivery/repository/DeliveryRepository.java
@@ -9,4 +9,6 @@ import personal.yejin.foodDelivery.domain.delivery.model.DeliveryStatus;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     List<Delivery> findByIdIsNotAndDeliveryTypeAndStatus(Long id, DeliveryType deliveryType, DeliveryStatus status);
+
+    List<Delivery> findByRiderIdAndStatusIn(Long riderId, List<DeliveryStatus> statuses);
 }

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/controller/OrderNotificationController.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/controller/OrderNotificationController.java
@@ -1,0 +1,23 @@
+package personal.yejin.foodDelivery.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import personal.yejin.foodDelivery.domain.order.service.OrderDeliveryNotificationService;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderNotificationController {
+
+    private final OrderDeliveryNotificationService orderDeliveryNotificationService;
+
+    @GetMapping(path = "/{orderId}/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable Long orderId) {
+        return orderDeliveryNotificationService.subscribeOrderNotification(orderId);
+    }
+}

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/dto/OrderNearArrivalNotification.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/dto/OrderNearArrivalNotification.java
@@ -1,0 +1,19 @@
+package personal.yejin.foodDelivery.domain.order.dto;
+
+public record OrderNearArrivalNotification(
+        Long orderId,
+        Long deliveryId,
+        Long riderId,
+        double remainingDistanceKm,
+        String message
+) {
+    public static OrderNearArrivalNotification of(Long orderId, Long deliveryId, Long riderId, double remainingDistanceKm) {
+        return new OrderNearArrivalNotification(
+                orderId,
+                deliveryId,
+                riderId,
+                remainingDistanceKm,
+                "라이더가 곧 도착합니다."
+        );
+    }
+}

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/service/OrderDeliveryNotificationService.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/service/OrderDeliveryNotificationService.java
@@ -1,0 +1,83 @@
+package personal.yejin.foodDelivery.domain.order.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import personal.yejin.foodDelivery.domain.delivery.model.Delivery;
+import personal.yejin.foodDelivery.domain.order.dto.OrderNearArrivalNotification;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+@Slf4j
+public class OrderDeliveryNotificationService {
+
+    private static final long SSE_TIMEOUT_MILLIS = 60L * 60 * 1000;
+    private static final String NEAR_ARRIVAL_EVENT_NAME = "delivery-near-arrival";
+
+    private final Map<Long, List<SseEmitter>> orderEmitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribeOrderNotification(Long orderId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        orderEmitters.computeIfAbsent(orderId, key -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        registerEmitterLifecycleCallbacks(orderId, emitter);
+        sendConnectEvent(orderId, emitter);
+        return emitter;
+    }
+
+    public void notifyNearArrival(Delivery delivery, double remainingDistanceKm) {
+        Long orderId = delivery.getOrder().getId();
+        OrderNearArrivalNotification payload = OrderNearArrivalNotification.of(
+                orderId,
+                delivery.getId(),
+                delivery.getRider().getId(),
+                remainingDistanceKm
+        );
+
+        List<SseEmitter> emitters = orderEmitters.getOrDefault(orderId, List.of());
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(NEAR_ARRIVAL_EVENT_NAME)
+                        .data(payload));
+            } catch (IOException e) {
+                log.warn("Near arrival SSE 전송 실패. orderId={}, deliveryId={}", orderId, delivery.getId(), e);
+                removeEmitter(orderId, emitter);
+            }
+        }
+    }
+
+    private void registerEmitterLifecycleCallbacks(Long orderId, SseEmitter emitter) {
+        emitter.onCompletion(() -> removeEmitter(orderId, emitter));
+        emitter.onTimeout(() -> removeEmitter(orderId, emitter));
+        emitter.onError(error -> removeEmitter(orderId, emitter));
+    }
+
+    private void removeEmitter(Long orderId, SseEmitter emitter) {
+        List<SseEmitter> emitters = orderEmitters.get(orderId);
+        if (emitters == null) {
+            return;
+        }
+        emitters.remove(emitter);
+        if (emitters.isEmpty()) {
+            orderEmitters.remove(orderId);
+        }
+    }
+
+    private void sendConnectEvent(Long orderId, SseEmitter emitter) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data("orderId=" + orderId)
+            );
+        } catch (IOException e) {
+            removeEmitter(orderId, emitter);
+            throw new RuntimeException("Order SSE 연결 실패");
+        }
+    }
+}

--- a/src/main/java/personal/yejin/foodDelivery/domain/rider/service/RiderService.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/rider/service/RiderService.java
@@ -4,6 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import personal.yejin.foodDelivery.domain.delivery.model.Delivery;
+import personal.yejin.foodDelivery.domain.delivery.model.DeliveryStatus;
+import personal.yejin.foodDelivery.domain.delivery.repository.DeliveryRepository;
+import personal.yejin.foodDelivery.domain.order.service.OrderDeliveryNotificationService;
 import personal.yejin.foodDelivery.domain.rider.dto.RiderLocationResponse;
 import personal.yejin.foodDelivery.domain.rider.model.Location;
 import personal.yejin.foodDelivery.domain.rider.model.Rider;
@@ -11,21 +15,26 @@ import personal.yejin.foodDelivery.domain.rider.model.RiderStatus;
 import personal.yejin.foodDelivery.domain.rider.repository.RiderRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Comparator;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RiderService {
+    private static final double NEAR_ARRIVAL_THRESHOLD_KM = 0.5;
 
     private final RiderRepository riderRepository;
+    private final DeliveryRepository deliveryRepository;
+    private final OrderDeliveryNotificationService orderDeliveryNotificationService;
 
+    @Transactional
     public RiderLocationResponse updateRiderLocation(Long riderId, double latitude, double longitude) {
         Rider rider = riderRepository.findById(riderId)
                 .orElseThrow(() -> new IllegalArgumentException("라이더 아이디가 존재하지 않습니다." + riderId));
 
         rider.updateLocation(latitude, longitude);
-        riderRepository.save(rider);
+        notifyNearArrivalIfNeeded(rider);
 
         return new RiderLocationResponse(
                 rider.getId(),
@@ -33,6 +42,27 @@ public class RiderService {
                 rider.getLocation().getLongitude(),
                 rider.getUpdatedAt()
         );
+    }
+
+    private void notifyNearArrivalIfNeeded(Rider rider) {
+        List<Delivery> activeDeliveries = deliveryRepository.findByRiderIdAndStatusIn(
+                rider.getId(),
+                List.of(DeliveryStatus.DISPATCHED, DeliveryStatus.PICKED_UP)
+        );
+
+        for (Delivery delivery : activeDeliveries) {
+            if (delivery.isNearArrivalNotified()) {
+                continue;
+            }
+
+            Location destination = delivery.getOrder().getDeliveryLocation();
+            double distanceKm = rider.getLocation().calculateDistanceInHaversineFormula(destination);
+
+            if (distanceKm <= NEAR_ARRIVAL_THRESHOLD_KM) {
+                orderDeliveryNotificationService.notifyNearArrival(delivery, distanceKm);
+                delivery.markNearArrivalNotified();
+            }
+        }
     }
 
     public RiderLocationResponse getRiderLocation(Long riderId) {

--- a/src/test/java/personal/yejin/foodDelivery/domain/rider/OrderNearArrivalNotificationIntegrationTest.java
+++ b/src/test/java/personal/yejin/foodDelivery/domain/rider/OrderNearArrivalNotificationIntegrationTest.java
@@ -1,0 +1,107 @@
+package personal.yejin.foodDelivery.domain.rider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import personal.yejin.foodDelivery.domain.delivery.dto.DispatchRequest;
+import personal.yejin.foodDelivery.domain.delivery.model.DeliveryType;
+import personal.yejin.foodDelivery.domain.delivery.repository.DeliveryRepository;
+import personal.yejin.foodDelivery.domain.order.model.Order;
+import personal.yejin.foodDelivery.domain.order.model.OrderStatus;
+import personal.yejin.foodDelivery.domain.order.repository.OrderRepository;
+import personal.yejin.foodDelivery.domain.rider.dto.RiderLocationRequest;
+import personal.yejin.foodDelivery.domain.rider.model.Location;
+import personal.yejin.foodDelivery.domain.rider.model.Rider;
+import personal.yejin.foodDelivery.domain.rider.model.RiderStatus;
+import personal.yejin.foodDelivery.domain.rider.repository.RiderRepository;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrderNearArrivalNotificationIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private RiderRepository riderRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private DeliveryRepository deliveryRepository;
+
+    @Test
+    @DisplayName("주문자 SSE 구독 후 라이더가 도착지 근접 시 near-arrival 알림을 수신한다")
+    void customerReceivesNearArrivalNotification() {
+        deliveryRepository.deleteAll();
+        orderRepository.deleteAll();
+        riderRepository.deleteAll();
+
+        Rider rider = riderRepository.save(Rider.builder()
+                .name("근접테스트 라이더")
+                .status(RiderStatus.READY)
+                .location(new Location(37.5000, 127.0000))
+                .build());
+
+        Order order = orderRepository.save(Order.builder()
+                .storeId(10L)
+                .pickupLocation(new Location(37.5005, 127.0005))
+                .deliveryLocation(new Location(37.5200, 127.0200))
+                .deliveryAddress("서울시 강남구")
+                .orderStatus(OrderStatus.CREATED)
+                .deliveryType(DeliveryType.SINGLE)
+                .build());
+
+        Long orderId = order.getId();
+
+        Flux<String> orderNotificationStream = webTestClient.get()
+                .uri("/orders/" + orderId + "/notifications/subscribe")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+                .returnResult(String.class)
+                .getResponseBody();
+
+        StepVerifier.create(orderNotificationStream)
+                .assertNext(event -> {
+                    log.info(">>> [ORDER SSE CONNECTED] {}", event);
+                    assertThat(event).contains("orderId=" + orderId);
+                })
+                .then(() -> {
+                    webTestClient.post()
+                            .uri("/deliveries/" + orderId + "/dispatch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(new DispatchRequest(DeliveryType.SINGLE))
+                            .exchange()
+                            .expectStatus().isOk();
+                })
+                .then(() -> {
+                    webTestClient.post()
+                            .uri("/riders/" + rider.getId() + "/location")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(new RiderLocationRequest(37.5201, 127.0201))
+                            .exchange()
+                            .expectStatus().isCreated();
+                })
+                .assertNext(event -> {
+                    log.info(">>> [ORDER NEAR ARRIVAL EVENT] {}", event);
+                    assertThat(event).contains("\"orderId\":" + orderId);
+                    assertThat(event).contains("\"riderId\":" + rider.getId());
+                    assertThat(event).contains("delivery-near-arrival");
+                })
+                .thenCancel()
+                .verify(Duration.ofSeconds(20));
+    }
+}


### PR DESCRIPTION
### Motivation
- Notify customers when a rider is close to the delivery destination by reusing existing rider location updates and SSE notification patterns. 
- Prevent duplicate notifications for the same delivery by persisting a sent flag on the delivery entity.

### Description
- Add `nearArrivalNotified` boolean to `Delivery` with `markNearArrivalNotified()` and default `false` to guard duplicate sends. 
- Add repository helper `findByRiderIdAndStatusIn` to query active deliveries for a rider. 
- Implement `OrderDeliveryNotificationService` and `OrderNotificationController` to expose `GET /orders/{orderId}/notifications/subscribe` and emit `delivery-near-arrival` SSE events with `OrderNearArrivalNotification` payload. 
- Extend `RiderService.updateRiderLocation` to check active deliveries (statuses `DISPATCHED`, `PICKED_UP`), compute distance (threshold `0.5 km`), call notification service when within threshold, and mark deliveries as notified. 
- Add integration test `OrderNearArrivalNotificationIntegrationTest` covering subscribe → dispatch → rider location update → near-arrival SSE delivery.

### Testing
- Added integration test `OrderNearArrivalNotificationIntegrationTest` (not yet green in this environment). 
- Attempted to run tests with `./gradlew test --tests "*OrderNearArrivalNotificationIntegrationTest" --tests "*RiderNotificationIntegrationTest"`, but the build failed during dependency resolution because Maven Central returned HTTP 403, blocking compilation and test execution. 
- Code changes were compiled/validated locally where possible (files added/updated) but full automated test run could not complete due to the environment network/dependency restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3cff9524832289683f3f2720d683)