### PR TITLE
Add 15% delay compensation coupon issuance on late pickup

### DIFF
--- a/src/main/java/personal/yejin/foodDelivery/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/delivery/service/DeliveryService.java
@@ -8,9 +8,13 @@ import personal.yejin.foodDelivery.domain.delivery.model.Delivery;
 import personal.yejin.foodDelivery.domain.delivery.model.DeliveryStatus;
 import personal.yejin.foodDelivery.domain.delivery.model.DeliveryType;
 import personal.yejin.foodDelivery.domain.delivery.repository.DeliveryRepository;
+import personal.yejin.foodDelivery.domain.order.service.DelayCompensationCouponService;
 import personal.yejin.foodDelivery.domain.rider.model.Location;
 import personal.yejin.foodDelivery.domain.rider.model.Rider;
 import personal.yejin.foodDelivery.domain.route.model.Route;
+import personal.yejin.foodDelivery.domain.route.model.StopType;
+
+import java.time.LocalDateTime;
 
 import java.util.Comparator;
 import java.util.Optional;
@@ -22,6 +26,7 @@ public class DeliveryService {
     private static final double BUNDLE_RADIUS_KM = 2.0;
     private final DeliveryRepository deliveryRepository;
     private final CacheManager cacheManager;
+    private final DelayCompensationCouponService delayCompensationCouponService;
 
     public boolean isBundleEligible(Delivery delivery) {
         return delivery.getDeliveryType() == DeliveryType.BUNDLE
@@ -33,8 +38,24 @@ public class DeliveryService {
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new IllegalArgumentException("Delivery not found with id: " + deliveryId));
         delivery.updateStatus(status);
+        if (status == DeliveryStatus.PICKED_UP && isDeliveryTimeExceeded(delivery, LocalDateTime.now())) {
+            delayCompensationCouponService.issueForDelayedDelivery(delivery.getOrder().getId());
+        }
         cacheManager.getCache("activateDeliveries").evict(delivery.getRider().getId());
         return delivery;
+    }
+
+    private boolean isDeliveryTimeExceeded(Delivery delivery, LocalDateTime now) {
+        if (delivery.getRoute() == null || delivery.getRoute().getStops() == null) {
+            return false;
+        }
+
+        return delivery.getRoute().getStops().stream()
+                .filter(stop -> stop.getDelivery() != null && stop.getDelivery().getId().equals(delivery.getId()))
+                .filter(stop -> stop.getType() == StopType.DELIVERY)
+                .map(stop -> stop.getEstimatedTime())
+                .filter(estimatedTime -> estimatedTime != null)
+                .anyMatch(now::isAfter);
     }
 
     @Transactional

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/model/DelayCompensationCoupon.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/model/DelayCompensationCoupon.java
@@ -1,0 +1,28 @@
+package personal.yejin.foodDelivery.domain.order.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import personal.yejin.foodDelivery.domain.common.GlobalEntity;
+
+@Entity
+@Table(name = "delay_compensation_coupons")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DelayCompensationCoupon extends GlobalEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long orderId;
+
+    @Column(nullable = false)
+    private int discountPercent;
+
+    @Column(nullable = false)
+    private String reason;
+}
+

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/repository/DelayCompensationCouponRepository.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/repository/DelayCompensationCouponRepository.java
@@ -1,0 +1,8 @@
+package personal.yejin.foodDelivery.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import personal.yejin.foodDelivery.domain.order.model.DelayCompensationCoupon;
+
+public interface DelayCompensationCouponRepository extends JpaRepository<DelayCompensationCoupon, Long> {
+    boolean existsByOrderId(Long orderId);
+}

--- a/src/main/java/personal/yejin/foodDelivery/domain/order/service/DelayCompensationCouponService.java
+++ b/src/main/java/personal/yejin/foodDelivery/domain/order/service/DelayCompensationCouponService.java
@@ -1,0 +1,30 @@
+package personal.yejin.foodDelivery.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import personal.yejin.foodDelivery.domain.order.model.DelayCompensationCoupon;
+import personal.yejin.foodDelivery.domain.order.repository.DelayCompensationCouponRepository;
+
+@Service
+@RequiredArgsConstructor
+public class DelayCompensationCouponService {
+
+    private static final int DELAY_COMPENSATION_DISCOUNT_PERCENT = 15;
+    private final DelayCompensationCouponRepository delayCompensationCouponRepository;
+
+    @Transactional
+    public void issueForDelayedDelivery(Long orderId) {
+        if (delayCompensationCouponRepository.existsByOrderId(orderId)) {
+            return;
+        }
+
+        DelayCompensationCoupon coupon = DelayCompensationCoupon.builder()
+                .orderId(orderId)
+                .discountPercent(DELAY_COMPENSATION_DISCOUNT_PERCENT)
+                .reason("고지된 배달 시간 초과 보상 쿠폰")
+                .build();
+
+        delayCompensationCouponRepository.save(coupon);
+    }
+}

--- a/src/test/java/personal/yejin/foodDelivery/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/personal/yejin/foodDelivery/domain/delivery/service/DeliveryServiceTest.java
@@ -1,0 +1,114 @@
+package personal.yejin.foodDelivery.domain.delivery.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import personal.yejin.foodDelivery.domain.delivery.model.Delivery;
+import personal.yejin.foodDelivery.domain.delivery.model.DeliveryStatus;
+import personal.yejin.foodDelivery.domain.delivery.repository.DeliveryRepository;
+import personal.yejin.foodDelivery.domain.order.model.Order;
+import personal.yejin.foodDelivery.domain.order.service.DelayCompensationCouponService;
+import personal.yejin.foodDelivery.domain.rider.model.Rider;
+import personal.yejin.foodDelivery.domain.route.model.Route;
+import personal.yejin.foodDelivery.domain.route.model.Stop;
+import personal.yejin.foodDelivery.domain.route.model.StopType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryServiceTest {
+
+    @Mock
+    private DeliveryRepository deliveryRepository;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache cache;
+
+    @Mock
+    private DelayCompensationCouponService delayCompensationCouponService;
+
+    @InjectMocks
+    private DeliveryService deliveryService;
+
+    @Test
+    @DisplayName("배달 시작(PICKED_UP) 시, 고지된 배달 시간 초과면 15% 보상 쿠폰을 발급한다")
+    void issueDelayCouponWhenPickedUpAfterPromisedTime() {
+        Delivery delivery = createDeliveryWithEstimatedDeliveryTime(LocalDateTime.now().minusMinutes(5));
+        when(deliveryRepository.findById(1L)).thenReturn(Optional.of(delivery));
+        when(cacheManager.getCache("activateDeliveries")).thenReturn(cache);
+
+        deliveryService.updateDeliveryStatus(1L, DeliveryStatus.PICKED_UP);
+
+        verify(delayCompensationCouponService).issueForDelayedDelivery(10L);
+        verify(cache).evict(100L);
+    }
+
+    @Test
+    @DisplayName("배달 시작(PICKED_UP) 시, 고지된 배달 시간 이내면 보상 쿠폰을 발급하지 않는다")
+    void doNotIssueDelayCouponWhenWithinPromisedTime() {
+        Delivery delivery = createDeliveryWithEstimatedDeliveryTime(LocalDateTime.now().plusMinutes(10));
+        when(deliveryRepository.findById(1L)).thenReturn(Optional.of(delivery));
+        when(cacheManager.getCache("activateDeliveries")).thenReturn(cache);
+
+        deliveryService.updateDeliveryStatus(1L, DeliveryStatus.PICKED_UP);
+
+        verify(delayCompensationCouponService, never()).issueForDelayedDelivery(anyLong());
+        verify(cache).evict(100L);
+    }
+
+    @Test
+    @DisplayName("배달 시작 상태가 아니면 고지 시간 초과여도 보상 쿠폰을 발급하지 않는다")
+    void doNotIssueDelayCouponWhenStatusIsNotPickedUp() {
+        Delivery delivery = createDeliveryWithEstimatedDeliveryTime(LocalDateTime.now().minusMinutes(5));
+        when(deliveryRepository.findById(1L)).thenReturn(Optional.of(delivery));
+        when(cacheManager.getCache("activateDeliveries")).thenReturn(cache);
+
+        deliveryService.updateDeliveryStatus(1L, DeliveryStatus.DELIVERED);
+
+        verify(delayCompensationCouponService, never()).issueForDelayedDelivery(anyLong());
+        verify(cache).evict(100L);
+    }
+
+    private Delivery createDeliveryWithEstimatedDeliveryTime(LocalDateTime estimatedTime) {
+        Order order = Order.builder().id(10L).build();
+        Rider rider = Rider.builder().id(100L).build();
+
+        Delivery delivery = Delivery.builder()
+                .id(1L)
+                .order(order)
+                .rider(rider)
+                .status(DeliveryStatus.DISPATCHED)
+                .build();
+
+        Stop deliveryStop = Stop.builder()
+                .delivery(delivery)
+                .type(StopType.DELIVERY)
+                .estimatedTime(estimatedTime)
+                .sequence(2)
+                .build();
+
+        Route route = Route.builder()
+                .stops(List.of(deliveryStop))
+                .build();
+
+        return Delivery.builder()
+                .id(1L)
+                .order(order)
+                .rider(rider)
+                .route(route)
+                .status(DeliveryStatus.DISPATCHED)
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation
- 보낸 배달 시작 시점(`PICKED_UP`)이 고객에게 고지했던 예상 배달 시간(`Stop.estimatedTime`)을 초과하면 사용자에게 15% 보상 쿠폰을 발급하는 정책을 코드에 반영하기 위해 변경했습니다.

### Description
- 새로운 엔티티 `DelayCompensationCoupon`을 추가해 주문 기준 지연 보상 쿠폰을 저장하도록 했습니다 (`src/main/java/.../DelayCompensationCoupon.java`).
- `DelayCompensationCouponRepository`와 `DelayCompensationCouponService`를 추가해 주문당 중복 발급을 방지하는 idempotent 발급 로직을 구현했습니다 (`.../DelayCompensationCouponRepository.java`, `.../DelayCompensationCouponService.java`).
- `DeliveryService.updateDeliveryStatus`에 상태가 `PICKED_UP`으로 변경될 때 해당 배달의 라우트에서 배송 스탑(`StopType.DELIVERY`)의 `estimatedTime`을 비교하여 기한을 초과하면 쿠폰 발급 서비스를 호출하도록 변경하고, 이를 판단하는 `isDeliveryTimeExceeded` 헬퍼를 추가했습니다 (`src/main/java/.../DeliveryService.java`).
- 지연/비지연/비시작 상태를 검증하는 단위 테스트 `DeliveryServiceTest`를 추가했습니다 (`src/test/java/.../DeliveryServiceTest.java`).

### Testing
- 단위 테스트 `./gradlew test --tests "personal.yejin.foodDelivery.domain.delivery.service.DeliveryServiceTest"`를 실행하려고 시도했으며 의존성 다운로드 실패(`Maven Central 403 Forbidden`)로 인해 빌드/테스트가 완료되지 않았습니다.
- 테스트 자체는 새 케이스(지연 발급, 시간 내 미발급, 비-`PICKED_UP` 상태 미발급)를 추가했으며, 환경 의존성 문제 해결 시 자동화된 테스트로 검증 가능합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec525fa888322ba61b5beb9a043ea)