### PR TITLE
[Chores/deploy] 멀티 모듈 프로젝트를 단일 AWS EC2 인스턴스에 배포하기 위한 도커 작업(docer-compose, dockerfile)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.gradle
+**/build
+!build
+**/out
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# 1단계: 빌드 환경 구성
+FROM eclipse-temurin:21-jdk AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 소스 코드를 모두 컨테이너 안으로 복사
+COPY . .
+
+# Gradle 래퍼에 실행 권한 부여
+RUN chmod +x ./gradlew
+
+# 어떤 모듈을 빌드할지 외부에서 인자(Argument)로 받음
+ARG MODULE_NAME
+
+# 선택한 모듈의 빌드 실행 (테스트 제외)
+RUN ./gradlew :${MODULE_NAME}:bootJar -x test
+
+# 2단계: 실제 실행 환경 구성 (가벼운 JRE 환경)
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+# 1단계에서 빌드할 때 사용했던 모듈 이름 가져오기
+ARG MODULE_NAME
+
+# 1단계 컨테이너(builder)에서 생성된 .jar 파일만 통째로 복사해서 현재 환경의 app.jar로 이름 변경
+COPY --from=builder /app/${MODULE_NAME}/build/libs/*SNAPSHOT.jar app.jar
+
+# 스프링 부트 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,19 @@ RUN ./gradlew :${MODULE_NAME}:bootJar -x test
 # 2단계: 실제 실행 환경 구성 (가벼운 JRE 환경)
 FROM eclipse-temurin:21-jre
 
+# 보안을 위해 root 계정 대신 사용할 애플리케이션 전용 계정(appuser) 생성
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
 WORKDIR /app
 
 # 1단계에서 빌드할 때 사용했던 모듈 이름 가져오기
 ARG MODULE_NAME
 
-# 1단계 컨테이너(builder)에서 생성된 .jar 파일만 통째로 복사해서 현재 환경의 app.jar로 이름 변경
-COPY --from=builder /app/${MODULE_NAME}/build/libs/*SNAPSHOT.jar app.jar
+# 1단계 컨테이너(builder)에서 생성된 .jar 파일 복사 시 소유권(chown)을 appuser로 지정
+COPY --from=builder --chown=appuser:appuser /app/${MODULE_NAME}/build/libs/*SNAPSHOT.jar app.jar
+
+# 이후부터 실행되는 모든 명령어는 appuser 권한으로 실행
+USER appuser
 
 # 스프링 부트 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Payment/build.gradle
+++ b/Payment/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
 }
 
 group = 'personal.yejin'
@@ -27,6 +29,13 @@ dependencies {
     // 공통 모듈
     implementation project(':common-event')
     implementation project(':common')
+}
+
+bootJar {
+    enabled = true
+}
+jar {
+    enabled = false
 }
 
 test {

--- a/Payment/build.gradle
+++ b/Payment/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // DB
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testRuntimeOnly 'com.h2database:h2'
+
     // 공통 모듈
     implementation project(':common-event')
     implementation project(':common')

--- a/Payment/src/main/java/personal/yejin/PaymentApplication.java
+++ b/Payment/src/main/java/personal/yejin/PaymentApplication.java
@@ -1,0 +1,11 @@
+package personal.yejin;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentApplication.class, args);
+    }
+}

--- a/Payment/src/main/resources/application.yml
+++ b/Payment/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://mysql-payment:3306/payment?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate.format_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE

--- a/Payment/src/main/resources/application.yml
+++ b/Payment/src/main/resources/application.yml
@@ -1,9 +1,13 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: payment-process-group
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://mysql-payment:3306/payment?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${PAYMENT_DB_HOST:mysql-payment}:${PAYMENT_DB_PORT:3306}/payment?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
 

--- a/PostPayment/build.gradle
+++ b/PostPayment/build.gradle
@@ -16,12 +16,21 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    implementation 'org.springframework.boot:spring-boot-starter'
+
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
     // 공통 모듈
     implementation project(':common-event')
     implementation project(':common')
+}
+
+bootJar {
+    enabled = true
+}
+jar {
+    enabled = false
 }
 
 test {

--- a/PostPayment/src/main/java/personal/yejin/PostPaymentApplication.java
+++ b/PostPayment/src/main/java/personal/yejin/PostPaymentApplication.java
@@ -1,0 +1,11 @@
+package personal.yejin;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PostPaymentApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PostPaymentApplication.class, args);
+    }
+}

--- a/PostPayment/src/main/resources/application.yml
+++ b/PostPayment/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: payment-result-group
+      auto-offset-reset: earliest

--- a/api-server/src/main/resources/application.yml
+++ b/api-server/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     import: optional:file:.env[.properties]
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:${MYSQL_PORT}/delivery?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${DATABASE_HOST:mysql}:${DATABASE_PORT:3306}/delivery?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,20 @@ services:
       - mysql-data:/var/lib/mysql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
+  mysql-payment:
+    image: mysql:8.0
+    container_name: mysql-payment-delivery
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: payment
+      MYSQL_USER: ${MYSQL_USERNAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "127.0.0.1:3307:3306"
+    volumes:
+      - mysql-payment-data:/var/lib/mysql
+
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
     container_name: zookeeper-delivery
@@ -34,8 +48,10 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   redis:
@@ -65,6 +81,7 @@ services:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
 
   payment-server:
     build:
@@ -75,13 +92,14 @@ services:
     # ports:
     #   - "8081:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
     depends_on:
-      - mysql
+      - mysql-payment
       - redis
       - kafka
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
 
   postpayment-server:
     build:
@@ -99,6 +117,7 @@ services:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
 
   status-server:
     build:
@@ -119,4 +138,5 @@ services:
 
 volumes:
   mysql-data:
+  mysql-payment-data:
   redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       MYSQL_DATABASE: delivery
       MYSQL_USER: ${MYSQL_USERNAME}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
       - "127.0.0.1:3306:3306"
     volumes:
@@ -24,6 +29,11 @@ services:
       MYSQL_DATABASE: payment
       MYSQL_USER: ${MYSQL_USERNAME}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
       - "127.0.0.1:3307:3306"
     volumes:
@@ -74,9 +84,12 @@ services:
     ports:
       - "8080:8080" # 외부에 노출되는 제일 중요한 서버포트
     depends_on:
-      - mysql
-      - redis
-      - kafka
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
@@ -92,9 +105,12 @@ services:
     # ports:
     #   - "8081:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
     depends_on:
-      - mysql-payment
-      - redis
-      - kafka
+      mysql-payment:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
@@ -110,9 +126,12 @@ services:
     # ports:
     #   - "8082:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
     depends_on:
-      - mysql
-      - redis
-      - kafka
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}
@@ -128,9 +147,12 @@ services:
     # ports:
     #   - "8083:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
     depends_on:
-      - mysql
-      - redis
-      - kafka
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - MYSQL_USERNAME=${MYSQL_USERNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,77 @@ services:
     volumes:
       - redis-data:/data
 
+  # ==========================================
+  # 어플리케이션 백엔드 서버 모듈들
+  # ==========================================
+  api-server:
+    build:
+      context: .
+      args:
+        MODULE_NAME: api-server
+    container_name: api-server-delivery
+    ports:
+      - "8080:8080" # 외부에 노출되는 제일 중요한 서버포트
+    depends_on:
+      - mysql
+      - redis
+      - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - MYSQL_USERNAME=${MYSQL_USERNAME}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+  payment-server:
+    build:
+      context: .
+      args:
+        MODULE_NAME: Payment
+    container_name: payment-delivery
+    # ports:
+    #   - "8081:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
+    depends_on:
+      - mysql
+      - redis
+      - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - MYSQL_USERNAME=${MYSQL_USERNAME}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+  postpayment-server:
+    build:
+      context: .
+      args:
+        MODULE_NAME: PostPayment
+    container_name: postpayment-delivery
+    # ports:
+    #   - "8082:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
+    depends_on:
+      - mysql
+      - redis
+      - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - MYSQL_USERNAME=${MYSQL_USERNAME}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+  status-server:
+    build:
+      context: .
+      args:
+        MODULE_NAME: status-server
+    container_name: status-delivery
+    # ports:
+    #   - "8083:8080" # api-server를 통해서만 접근하도록 외부 노출 포트를 닫음.
+    depends_on:
+      - mysql
+      - redis
+      - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - MYSQL_USERNAME=${MYSQL_USERNAME}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
 volumes:
   mysql-data:
   redis-data:


### PR DESCRIPTION
# PR 제목
멀티 모듈 프로젝트를 단일 AWS EC2 인스턴스에 배포하기 위한도커라이징 작업을 진행.

# PR 내용 
현재 4개의 Spring Boot 어플리케이션이 공존하는 Food-Delivery-Service 멀티 모듈 프로젝트를 단일 AWS EC2 인스턴스에 배포하기 위한도커라이징 작업을 진행했습니다. 일단은 단일 인스턴스에 컨테이너 단위로만 분리하여 배포를 진행하고, 후에 각 애플리케이선이 별도의 EC2에서 동작할 수 있도록 개선할 예정입니다.

- DockerFile 설정 
- ```.dockerIgnore``` 설정하여 DOCKERFILE에서 현재 프로젝트를 컨테이너로 copy해갈 때, 필요 없는 캐시 값들이 함께 복사되지 않게함.
- 각 모듈, 인프라 docker-compose 설정


### Kafka 외부망, 내부망 통신 port 설정 세부 내용 
```mermaid
graph TD
    subgraph "예진님의 로컬 PC (Host)"
        LocalApp["💻 로컬 IDE (IntelliJ) 등에서 실행한 App<br/><br/>접속 시도: localhost:9092"]
        
        subgraph "🐳 Docker 가상 네트워크 (bridge)"
            DockerApp["📦 payment-server 컨테이너<br/><br/>접속 시도: kafka:29092"]
            
            subgraph "Kafka 브로커 컨테이너"
                Listener1["🚪 내부망용 리스너 (PLAINTEXT)<br/>내부 포트: 29092"]
                Listener2["🚪 외부망용 리스너 (PLAINTEXT_HOST)<br/>내부 포트: 9092<br/>(PC의 9092 포트와 연결됨)"]
            end
        end
    end

    LocalApp -- "① localhost:9092 로 접속" --> Listener2
    DockerApp -- "① kafka:29092 로 접속" --> Listener1

    Listener1 -. "② 명함(Advertised) 반환:<br/>'앞으로 통신할 땐 kafka:29092로 와!'" .-> DockerApp
    Listener2 -. "② 명함(Advertised) 반환:<br/>'앞으로 통신할 땐 localhost:9092로 와!'" .-> LocalApp

    classDef container fill:#e1f5fe,stroke:#03a9f4,stroke-width:2px;
    classDef kafka fill:#fff3e0,stroke:#ff9800,stroke-width:2px;
    classDef local fill:#f3e5f5,stroke:#ff9800,stroke-width:2px;
    
    class DockerApp,Listener1,Listener2 container;
    class LocalApp local;
```