### PR TITLE
[Feat/Payment] 결제 관련 transaction 처리 이후 after-commit 로직을 처리할 TransactionalEventHandler 추가  

### DIFF
--- a/Payment/src/main/java/personal/yejin/config/ExecutorConfig.java
+++ b/Payment/src/main/java/personal/yejin/config/ExecutorConfig.java
@@ -2,10 +2,12 @@ package personal.yejin.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+@EnableAsync
 @Configuration
 public class ExecutorConfig {
     @Bean

--- a/Payment/src/main/java/personal/yejin/handler/PaymentCompletedInternalEvent.java
+++ b/Payment/src/main/java/personal/yejin/handler/PaymentCompletedInternalEvent.java
@@ -1,0 +1,20 @@
+package personal.yejin.handler;
+
+import personal.yejin.model.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * Spring 내부 이벤트: PaymentRequestListener → PaymentEventHandler로 전달.
+ */
+public record PaymentCompletedInternalEvent(
+        String correlationId,
+        Long paymentId,
+        Long orderId,
+        Long userId,
+        PaymentStatus paymentStatus,
+        LocalDateTime timestamp,
+        int finalPrice,
+        String failureReason
+) {
+}

--- a/Payment/src/main/java/personal/yejin/handler/PaymentEventHandler.java
+++ b/Payment/src/main/java/personal/yejin/handler/PaymentEventHandler.java
@@ -1,0 +1,60 @@
+package personal.yejin.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import personal.yejin.PaymentResultEvent;
+import personal.yejin.client.StatusServerClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventHandler {
+
+    private static final String KAFKA_PAYMENT_RESULT_TOPIC = "payment-result";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final StatusServerClient statusServerClient;
+
+    /**
+     * 트랜잭션 커밋 후 비동기로 실행된다.
+     * - Kafka에 결제 결과 이벤트 발행
+     * - Status Server에 결제 상태 업데이트
+     */
+    @Async("virtualThreadExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompleted(PaymentCompletedInternalEvent event) {
+        log.info("트랜잭션 커밋 후 이벤트 수신: orderId={}, correlationId={}, status={}",
+                event.orderId(), event.correlationId(), event.paymentStatus());
+
+        // 1. Kafka 결과 이벤트 발행
+        PaymentResultEvent resultEvent = new PaymentResultEvent(
+                event.correlationId(),
+                event.paymentId(),
+                event.orderId(),
+                event.userId(),
+                event.paymentStatus(),
+                event.timestamp(),
+                event.finalPrice(),
+                event.failureReason()
+        );
+
+        kafkaTemplate.send(KAFKA_PAYMENT_RESULT_TOPIC, resultEvent);
+        log.info("PAYMENT_RESULT_TOPIC 발행: orderId={}, correlationId={}",
+                event.orderId(), event.correlationId());
+
+        // 2. Status Server에 상태 업데이트
+        try {
+            statusServerClient.updatePaymentStatus(
+                    event.orderId(), event.correlationId(),
+                    event.paymentStatus(), event.failureReason());
+        } catch (Exception e) {
+            log.error("Status server 업데이트 중 오류 발생: orderId={}, correlationId={}",
+                    event.orderId(), event.correlationId(), e);
+        }
+    }
+}

--- a/Payment/src/main/java/personal/yejin/handler/PaymentEventHandler.java
+++ b/Payment/src/main/java/personal/yejin/handler/PaymentEventHandler.java
@@ -43,9 +43,15 @@ public class PaymentEventHandler {
                 event.failureReason()
         );
 
-        kafkaTemplate.send(KAFKA_PAYMENT_RESULT_TOPIC, resultEvent);
-        log.info("PAYMENT_RESULT_TOPIC 발행: orderId={}, correlationId={}",
-                event.orderId(), event.correlationId());
+
+        try {
+            kafkaTemplate.send(KAFKA_PAYMENT_RESULT_TOPIC, resultEvent);
+            log.info("PAYMENT_RESULT_TOPIC 발행: orderId={}, correlationId={}",
+                    event.orderId(), event.correlationId());
+        } catch (Exception e) {
+            log.error("Kafka PAYMENT_RESULT_TOPIC 발행 중 오류 발생 : orderId={}, correlationId={}",
+                    event.orderId(), event.correlationId(), e);
+        }
 
         // 2. Status Server에 상태 업데이트
         try {
@@ -53,8 +59,6 @@ public class PaymentEventHandler {
                     event.orderId(), event.correlationId(),
                     event.paymentStatus(), event.failureReason());
         } catch (Exception e) {
-            log.error("Status server 업데이트 중 오류 발생: orderId={}, correlationId={}",
-                    event.orderId(), event.correlationId(), e);
         }
     }
 }

--- a/Payment/src/main/java/personal/yejin/kafkaListner/PaymentRequestListener.java
+++ b/Payment/src/main/java/personal/yejin/kafkaListner/PaymentRequestListener.java
@@ -1,16 +1,12 @@
 package personal.yejin.kafkaListner;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import personal.yejin.PaymentRequestEvent;
-import personal.yejin.PaymentResultEvent;
-import personal.yejin.client.StatusServerClient;
-import personal.yejin.config.ExecutorConfig;
+import personal.yejin.handler.PaymentCompletedInternalEvent;
 import personal.yejin.model.Payment;
 import personal.yejin.model.PaymentMethod;
 import personal.yejin.model.PaymentStatus;
@@ -20,26 +16,26 @@ import personal.yejin.service.CashPaymentAPI;
 import personal.yejin.service.PaymentAPI;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PaymentRequestListener {
-
-    private static final String KAFKA_PAYMENT_RESULT_TOPIC = "payment-result";
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+ 
     private final PaymentRepository paymentRepository;
-    private final StatusServerClient statusServerClient;
-    private final ExecutorConfig executorConfig;
-    private final Map<PaymentMethod, PaymentAPI> paymentAPIMap = new HashMap<>();
+    private final ApplicationEventPublisher eventPublisher;
+    private final Map<PaymentMethod, PaymentAPI> paymentAPIMap;
 
-    @PostConstruct
-    private void init() {
-        paymentAPIMap.put(PaymentMethod.CARD, new CardPaymentAPI());
-        paymentAPIMap.put(PaymentMethod.CASH, new CashPaymentAPI());
+    public PaymentRequestListener(PaymentRepository paymentRepository,
+                                  ApplicationEventPublisher eventPublisher,
+                                  List<PaymentAPI> paymentAPIs) {
+        this.paymentRepository = paymentRepository;
+        this.eventPublisher = eventPublisher;
+        this.paymentAPIMap = paymentAPIs.stream()
+                .collect(Collectors.toMap(PaymentAPI::getSupportedMethod, Function.identity()));
     }
 
     @Transactional
@@ -65,16 +61,13 @@ public class PaymentRequestListener {
             failureReason = "결제 처리 중 오류: " + e.getMessage();
         }
 
-        // 3. Payment 상태 업데이트
+        // 3. Payment 상태 업데이트 (dirty checking으로 커밋 시 DB 반영)
         PaymentStatus paymentStatus = isPaymentSuccess ? PaymentStatus.SUCCESS : PaymentStatus.FAIL;
         payment.setStatus(paymentStatus);
         payment.setFailReason(failureReason);
 
-        // 4. Status Server에 상태 업데이트
-        sendPaymentStatusToStatusServerAsync(request.orderId(), request.correlationId(), failureReason, paymentStatus);
-
-        // 5. 결과 이벤트 발행 (성공/실패 모두)
-        PaymentResultEvent event = new PaymentResultEvent(
+        // 4. Spring 내부 이벤트 발행 → 트랜잭션 커밋 후 PaymentEventHandler가 수신
+        eventPublisher.publishEvent(new PaymentCompletedInternalEvent(
                 request.correlationId(),
                 payment.getId(),
                 request.orderId(),
@@ -83,20 +76,10 @@ public class PaymentRequestListener {
                 LocalDateTime.now(),
                 request.finalPrice(),
                 failureReason
-        );
+        ));
 
-        kafkaTemplate.send(KAFKA_PAYMENT_RESULT_TOPIC, event);
-        log.info("PYMENT_RESULT_TOPIC 밸행 : orderId={}, correlationId={}", request.orderId(), request.correlationId());
-    }
-
-    private void sendPaymentStatusToStatusServerAsync(long orderId, String correlationId, String failureReason, PaymentStatus status) {
-        CompletableFuture.runAsync(() -> {
-            statusServerClient.updatePaymentStatus(
-                    orderId, correlationId, status, failureReason);
-        }, executorConfig.virtualThreadExecutor()).exceptionally(ex -> {
-            log.error("Status server 비동기 업데이트 중 오류 발생: orderId={}, correlationId={}", orderId, correlationId, ex);
-            return null;
-        });
+        log.info("결제 처리 완료, 내부 이벤트 발행: orderId={}, correlationId={}, status={}",
+                request.orderId(), request.correlationId(), paymentStatus);
     }
 
     private boolean callPaymentApi(PaymentRequestEvent request, PaymentMethod paymentMethod) {

--- a/Payment/src/test/java/PaymentEventHandlerUnitTest.java
+++ b/Payment/src/test/java/PaymentEventHandlerUnitTest.java
@@ -1,0 +1,95 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import personal.yejin.PaymentResultEvent;
+import personal.yejin.client.StatusServerClient;
+import personal.yejin.handler.PaymentCompletedInternalEvent;
+import personal.yejin.handler.PaymentEventHandler;
+import personal.yejin.model.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentEventHandlerUnitTest {
+
+    @Mock
+    KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    StatusServerClient statusServerClient;
+
+    @InjectMocks
+    PaymentEventHandler handler;
+
+    @Test
+    @DisplayName("결제 완료 이벤트를 받으면 Kafka 결과 이벤트를 발행하고, Status Server에 상태를 업데이트한다.")
+    void 성공_이벤트_처리시_Kafka_발행_및_StatusServer_업데이트() {
+        PaymentCompletedInternalEvent event = new PaymentCompletedInternalEvent(
+                "corr-1", 100L, 5001L, 1L,
+                PaymentStatus.SUCCESS, LocalDateTime.now(), 18000, null
+        );
+
+        handler.handlePaymentCompleted(event);
+
+        // Kafka 발행 검증
+        ArgumentCaptor<PaymentResultEvent> captor = ArgumentCaptor.forClass(PaymentResultEvent.class);
+        verify(kafkaTemplate).send(eq("payment-result"), captor.capture());
+
+        PaymentResultEvent result = captor.getValue();
+        assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(result.orderId()).isEqualTo(5001L);
+        assertThat(result.failureReason()).isNull();
+
+        // Status Server 업데이트 검증
+        verify(statusServerClient).updatePaymentStatus(
+                eq(5001L), eq("corr-1"), eq(PaymentStatus.SUCCESS), isNull());
+    }
+
+    @Test
+    @DisplayName("실패 이벤트 처리시 실패 사유가 포함된 Kafka 이벤트를 발행한다.")
+    void 실패_이벤트_처리시_실패사유_포함() {
+        PaymentCompletedInternalEvent event = new PaymentCompletedInternalEvent(
+                "corr-2", 101L, 5002L, 2L,
+                PaymentStatus.FAIL, LocalDateTime.now(), 10000, "잔액 부족"
+        );
+
+        handler.handlePaymentCompleted(event);
+
+        ArgumentCaptor<PaymentResultEvent> captor = ArgumentCaptor.forClass(PaymentResultEvent.class);
+        verify(kafkaTemplate).send(eq("payment-result"), captor.capture());
+
+        PaymentResultEvent result = captor.getValue();
+        assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.FAIL);
+        assertThat(result.failureReason()).isEqualTo("잔액 부족");
+
+        verify(statusServerClient).updatePaymentStatus(
+                eq(5002L), eq("corr-2"), eq(PaymentStatus.FAIL), eq("잔액 부족"));
+    }
+
+    @Test
+    @DisplayName("Status Server 업데이트 실패해도 예외가 전파되지 않는다.")
+    void StatusServer_실패해도_예외_전파_안됨() {
+        PaymentCompletedInternalEvent event = new PaymentCompletedInternalEvent(
+                "corr-3", 102L, 5003L, 3L,
+                PaymentStatus.SUCCESS, LocalDateTime.now(), 15000, null
+        );
+
+        doThrow(new RuntimeException("연결 실패"))
+                .when(statusServerClient).updatePaymentStatus(anyLong(), anyString(), any(), any());
+
+        // 예외가 전파되지 않아야 함
+        handler.handlePaymentCompleted(event);
+
+        // Kafka는 정상 발행됨
+        verify(kafkaTemplate).send(eq("payment-result"), any(PaymentResultEvent.class));
+    }
+}

--- a/Payment/src/test/java/PaymentRequestListenerTest.java
+++ b/Payment/src/test/java/PaymentRequestListenerTest.java
@@ -2,12 +2,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import personal.yejin.PaymentRequestEvent;
-import personal.yejin.PaymentResultEvent;
+import personal.yejin.handler.PaymentCompletedInternalEvent;
 import personal.yejin.kafkaListner.PaymentRequestListener;
 import personal.yejin.model.Payment;
 import personal.yejin.model.PaymentMethod;
@@ -15,8 +16,10 @@ import personal.yejin.model.PaymentStatus;
 import personal.yejin.repository.PaymentRepository;
 import personal.yejin.service.PaymentAPI;
 
+import java.util.List;
 import java.util.Map;
-
+ 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -24,17 +27,13 @@ import static org.mockito.Mockito.*;
 class PaymentRequestListenerTest {
 
     @Mock
-    Map<PaymentMethod, PaymentAPI> paymentAPIMap;
-
+    PaymentRepository paymentRepository;
+ 
     @Mock
-    KafkaTemplate<String, Object> kafkaTemplate;
-
-    @Mock
-    PaymentRepository paymentRepository; // TODO : 가짜객체이므로 JPA가 동작하지 않는다. 따라서 통합테스트로 변경하여 실제로 상태가 SUCCESS로 바뀌어서 DB에 반영됐는지"를 검증
-
-    @InjectMocks
+    ApplicationEventPublisher eventPublisher;
+ 
     PaymentRequestListener listener;
-
+ 
     @Mock
     PaymentAPI paymentAPI;
 
@@ -44,55 +43,64 @@ class PaymentRequestListenerTest {
 
     @BeforeEach
     void setUp() {
+        when(paymentAPI.getSupportedMethod()).thenReturn(PaymentMethod.CARD);
+        listener = new PaymentRequestListener(paymentRepository, eventPublisher, List.of(paymentAPI));
+
         when(paymentRepository.save(any(Payment.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
-        when(paymentAPIMap.get(any(PaymentMethod.class))).thenReturn(paymentAPI);
     }
 
-
-    // TODO : 후에 status update에 대한 로직도 추가해야함.
     @Test
-    @DisplayName("결제 성공시, payment를 DB에 SUCCESS로 저장하고, 성공 이벤트를 발행한다.")
-    void 결제_성공시_SUCCESS로_저장되고_이벤트_발행() {
+    @DisplayName("결제 성공시, Payment를 PENDING으로 저장하고, SUCCESS 상태의 내부 이벤트를 발행한다.")
+    void 결제_성공시_SUCCESS_이벤트_발행() {
         when(paymentAPI.pay(10000, PaymentMethod.CARD)).thenReturn(true);
 
         listener.consumePaymentRequest(request);
 
-        verify(paymentRepository, times(1)).save(argThat(
-                payment -> payment.getStatus() == PaymentStatus.SUCCESS
-        ));
+        // Payment가 PENDING 상태로 save 호출됨 (dirty checking으로 이후 SUCCESS로 변경)
+        verify(paymentRepository, times(1)).save(any(Payment.class));
 
-        verify(kafkaTemplate).send(eq("payment-result"), argThat(
-                event -> ((PaymentResultEvent) event).failureReason() == null
-        ));
+        // Spring 내부 이벤트가 SUCCESS 상태로 발행됨
+        ArgumentCaptor<PaymentCompletedInternalEvent> captor =
+                ArgumentCaptor.forClass(PaymentCompletedInternalEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        PaymentCompletedInternalEvent event = captor.getValue();
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(event.failureReason()).isNull();
+        assertThat(event.orderId()).isEqualTo(1L);
     }
 
     @Test
-    @DisplayName("결제 API 처리 실패시, payment를 DB에 FAILED로 저장하고, 실패 이벤트를 발행한다.")
-    void 결제_실패시_FAILED로_저장되고_실패사유_담김() {
+    @DisplayName("결제 API 처리 실패시, FAIL 상태의 내부 이벤트를 발행한다.")
+    void 결제_실패시_FAIL_이벤트_발행() {
         when(paymentAPI.pay(10000, PaymentMethod.CARD)).thenReturn(false);
 
         listener.consumePaymentRequest(request);
 
-        verify(paymentRepository, times(1)).save(argThat(
-                payment -> payment.getStatus() == PaymentStatus.FAIL
-        ));
-        verify(kafkaTemplate).send(eq("payment-result"), argThat(
-                event -> ((PaymentResultEvent) event).failureReason() != null
-        ));
+        ArgumentCaptor<PaymentCompletedInternalEvent> captor =
+                ArgumentCaptor.forClass(PaymentCompletedInternalEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        PaymentCompletedInternalEvent event = captor.getValue();
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.FAIL);
+        assertThat(event.failureReason()).isNotNull();
     }
 
     @Test
-    @DisplayName("결제 API 처리중 예외 발생시, payment를 DB에 FAILED로 저장하고, 실패 이벤트를 발행한다.")
-    void 예외_발생해도_FAILED_이벤트_발행() {
+    @DisplayName("결제 API 처리중 예외 발생시, FAIL 상태의 내부 이벤트를 발행한다.")
+    void 예외_발생해도_FAIL_이벤트_발행() {
         when(paymentAPI.pay(10000, PaymentMethod.CARD))
                 .thenThrow(new RuntimeException("PG사 타임아웃"));
 
         listener.consumePaymentRequest(request);
 
-        verify(kafkaTemplate).send(eq("payment-result"), argThat(
-                event -> ((PaymentResultEvent) event).failureReason()
-                        .contains("PG사 타임아웃")
-        ));
+        ArgumentCaptor<PaymentCompletedInternalEvent> captor =
+                ArgumentCaptor.forClass(PaymentCompletedInternalEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        PaymentCompletedInternalEvent event = captor.getValue();
+        assertThat(event.paymentStatus()).isEqualTo(PaymentStatus.FAIL);
+        assertThat(event.failureReason()).contains("PG사 타임아웃");
     }
 }

--- a/status-server/build.gradle
+++ b/status-server/build.gradle
@@ -14,6 +14,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation project(':common-event')
     implementation project(':common')

--- a/status-server/src/main/java/personal/yejin/statusserver/controller/PaymentStatusController.java
+++ b/status-server/src/main/java/personal/yejin/statusserver/controller/PaymentStatusController.java
@@ -1,5 +1,6 @@
 package personal.yejin.statusserver.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ public class PaymentStatusController {
     @PutMapping("/{orderId}")
     public ResponseEntity<Void> updateStatus(
             @PathVariable Long orderId,
-            @RequestBody PaymentStatusUpdateRequest request) {
+            @Valid @RequestBody PaymentStatusUpdateRequest request) {
         paymentStatusService.updateStatus(orderId, request);
         return ResponseEntity.ok().build();
     }

--- a/status-server/src/main/java/personal/yejin/statusserver/dto/PaymentStatusUpdateRequest.java
+++ b/status-server/src/main/java/personal/yejin/statusserver/dto/PaymentStatusUpdateRequest.java
@@ -1,10 +1,12 @@
 package personal.yejin.statusserver.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import personal.yejin.model.PaymentStatus;
 
 public record PaymentStatusUpdateRequest(
-        String correlationId,
-        PaymentStatus status,
+        @NotBlank String correlationId,
+        @NotNull PaymentStatus status,
         String failureReason
 ) {
 }


### PR DESCRIPTION
# 결제 처리 이후 after commit 관련 내부 이벤트를 발행하는 TransactionalEventHandler 추가 

기존에는 결제 로직이 있는 부분에  transactionalSynchronnized 메서드를 적용하여 상태전송과 결제 결과 MQ 이벤트 발행을 하나의 소스코드에서 처리했으나, 결제 핵심 로직과 부가적인 로직들이 혼재됨에 따라서 클래스 책임을 줄이고자 TransactionEventHandler 클래스를 따로 분리하고 내부 이벤트 형식으로 처리되도록 변경하였습니다. 


결론 : 결제 이벤트 처리 흐름을 재구성. 기존에 결제 리스너(PaymentListener)가 Kafka로 결제 결과를 직접 발행하던 방식에서 내부 이벤트 기반 아키텍처로 변경되었으며, 비동기 이벤트 핸들러를 도입함.

- 결제 처리 정보가 DB에 update된 이후, TransactionalEventHandler가 서버 내부적으로 결제 완료 event를 발행. 
- PaymentEventHandler가 이를 수신하여 kafka에 결제 결과 이벤트를 발행하고, StatusServer에 상태를 update함. 
- PaymentEventHandler.handlePaymentCompleted 로직은 I/O bound 병목으로 인한 thread 대기 점유를 해소하기 위해 platform thread를 사용하는 것이 아닌, virtualThread를 적용함. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비동기 결제 처리 지원 추가로 응답 시간 개선
  * 내부 이벤트 기반 결제 상태 관리 시스템 도입

* **버그 수정 및 개선**
  * 결제 처리 중 발생하는 예외에 대한 안정성 강화
  * 결제 상태 업데이트 요청에 대한 데이터 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->